### PR TITLE
Add support for GitLab, Reddit, Bluesky, Mastodon, and Hacker News

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,21 @@
 
 
 ## Overview
-A simple CLI and server to check a name availability on Twitter and GitHub.
+A simple CLI and server to check a name availability on several websites, like GitHub, GitLab, Reddit, Bluesky, Mastodon and Hacker News.
+
+### Supported websites
+
+| Website | How the check works |
+|---|---|
+| GitHub | `https://github.com/<username>` answers 404 when the username is available |
+| GitLab | public REST API `https://gitlab.com/api/v4/users?username=<username>` answers `[]` when the username is available |
+| Reddit | `https://www.reddit.com/user/<username>/about.json` answers 404 when the username is available |
+| Bluesky | public AT Protocol API `com.atproto.identity.resolveHandle` answers 400 when the handle `<username>.bsky.social` is available |
+| Mastodon | public REST API `https://mastodon.social/api/v1/accounts/lookup?acct=<username>` answers 404 when the username is available (on the `mastodon.social` instance) |
+| Hacker News | official Firebase API `https://hacker-news.firebaseio.com/v0/user/<username>.json` answers `null` when the username is available |
+| Tinder | profile page scraping (`https://tinder.com/@<username>`) |
+| Twitter | simulated through a GCP Cloud Function (see Remarks below) |
+| Instagram | profile page scraping (disabled by default) |
 
 <img src="assets/img/name_diagram.jpg" alt="Namecheck diagram" title="Namecheck diagram" />
 

--- a/bluesky/bluesky.go
+++ b/bluesky/bluesky.go
@@ -1,0 +1,103 @@
+// Package bluesky provides primitives to check if an username
+// (a *.bsky.social handle) is available on Bluesky.
+package bluesky
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/internal"
+)
+
+type Bluesky struct {
+	Client namecheck.Client
+}
+
+const (
+	minLen        = 3
+	maxLen        = 18
+	illegalPrefix = "-"
+	illegalSuffix = "-"
+)
+
+var legalPattern = regexp.MustCompile("^[-0-9A-Za-z]*$")
+
+func (*Bluesky) String() string {
+	return "Bluesky"
+}
+
+func (*Bluesky) IsValid(username string) bool {
+	return internal.IsLongEnough(username, minLen) &&
+		internal.IsShortEnough(username, maxLen) &&
+		containsOnlyLegalChars(username) &&
+		containsNoIllegalPrefix(username) &&
+		containsNoIllegalSuffix(username)
+}
+
+// IsAvailable checks on Bluesky, the availability of the requested username
+// as a handle under the default bsky.social domain, using the public
+// AT Protocol API (no authentication required).
+// A 400 status code (unresolvable handle) indicates the username's
+// availability.
+func (bs *Bluesky) IsAvailable(ctx context.Context, username string) (bool, error) {
+	handle := strings.ToLower(username) + ".bsky.social"
+	endpoint := fmt.Sprintf(
+		"https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=%s",
+		url.QueryEscape(handle),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: bs.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+	resp, err := bs.Client.Do(req)
+	if err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: bs.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusBadRequest:
+		return true, nil
+	case http.StatusOK:
+		return false, nil
+	default:
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: bs.String(),
+			Cause:    fmt.Errorf("unexpected status code %d", resp.StatusCode),
+		}
+		return false, &err
+	}
+}
+
+func containsOnlyLegalChars(username string) bool {
+	return legalPattern.MatchString(username)
+}
+
+func containsNoIllegalPrefix(username string) bool {
+	return !strings.HasPrefix(username, illegalPrefix)
+}
+
+func containsNoIllegalSuffix(username string) bool {
+	return !strings.HasSuffix(username, illegalSuffix)
+}

--- a/bluesky/bluesky_test.go
+++ b/bluesky/bluesky_test.go
@@ -1,0 +1,80 @@
+package bluesky_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/bluesky"
+	"github.com/davidaparicio/namecheck/stub"
+)
+
+var _ namecheck.Checker = (*bluesky.Bluesky)(nil)
+
+func TestIsValid(t *testing.T) {
+	cases := []struct {
+		username string
+		want     bool
+	}{
+		{"jay", true},
+		{"david-aparicio", true},
+		{"ab", false},                         // too short
+		{"longer-than-eighteen-chars", false}, // too long
+		{"-david", false},                     // illegal prefix
+		{"david-", false},                     // illegal suffix
+		{"david_aparicio", false},             // illegal char
+	}
+	var bs bluesky.Bluesky
+	for _, c := range cases {
+		if got := bs.IsValid(c.username); got != c.want {
+			t.Errorf("IsValid(%q) = %t; want %t", c.username, got, c.want)
+		}
+	}
+}
+
+func TestIsAvailableUnresolvableHandle(t *testing.T) {
+	bs := bluesky.Bluesky{
+		Client: stub.ClientWithStatusCodeAndBody(
+			http.StatusBadRequest,
+			`{"error":"InvalidRequest","message":"Unable to resolve handle"}`,
+		),
+	}
+	avail, err := bs.IsAvailable(context.Background(), "whatever")
+	if !avail || err != nil {
+		t.Error("IsAvailable must return true on a 400 status code")
+	}
+}
+
+func TestIsAvailableTaken(t *testing.T) {
+	bs := bluesky.Bluesky{
+		Client: stub.ClientWithStatusCodeAndBody(http.StatusOK, `{"did":"did:plc:abc"}`),
+	}
+	avail, err := bs.IsAvailable(context.Background(), "whatever")
+	if avail || err != nil {
+		t.Error("IsAvailable must return false on a 200 status code")
+	}
+}
+
+func TestIsAvailableUnexpectedStatusCode(t *testing.T) {
+	bs := bluesky.Bluesky{
+		Client: stub.ClientWithStatusCode(http.StatusInternalServerError),
+	}
+	_, err := bs.IsAvailable(context.Background(), "whatever")
+	var uae *namecheck.UnknownAvailabilityError
+	if !errors.As(err, &uae) {
+		t.Error("IsAvailable must return an UnknownAvailabilityError on an unexpected status code")
+	}
+}
+
+func TestIsAvailableClientError(t *testing.T) {
+	bs := bluesky.Bluesky{
+		Client: stub.ClientWithError(errors.New("oh no")),
+	}
+	_, err := bs.IsAvailable(context.Background(), "whatever")
+	var uae *namecheck.UnknownAvailabilityError
+	if !errors.As(err, &uae) {
+		t.Error("IsAvailable must return an UnknownAvailabilityError on a client error")
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -11,7 +11,12 @@ import (
 	"time"
 
 	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/bluesky"
 	"github.com/davidaparicio/namecheck/github"
+	"github.com/davidaparicio/namecheck/gitlab"
+	"github.com/davidaparicio/namecheck/hackernews"
+	"github.com/davidaparicio/namecheck/mastodon"
+	"github.com/davidaparicio/namecheck/reddit"
 )
 
 //type Status int
@@ -36,21 +41,22 @@ func main() {
 	}
 	username := os.Args[1]
 
-	var checkers []namecheck.Checker
-	for i := 0; i < 3; i++ {
-		/*t := &twitter.Twitter{
-			Client: http.DefaultClient,
-		}*/
-		g := &github.GitHub{
-			Client: http.DefaultClient,
-		}
-		checkers = append(checkers, g)
+	/*t := &twitter.Twitter{
+		Client: http.DefaultClient,
+	}*/
+	checkers := []namecheck.Checker{
+		&github.GitHub{Client: http.DefaultClient},
+		&gitlab.GitLab{Client: http.DefaultClient},
+		&reddit.Reddit{Client: http.DefaultClient},
+		&bluesky.Bluesky{Client: http.DefaultClient},
+		&mastodon.Mastodon{Client: http.DefaultClient},
+		&hackernews.HackerNews{Client: http.DefaultClient},
 	}
 	results := make(chan Result, len(checkers))
 	errc := make(chan error, len(checkers))
 	var wg sync.WaitGroup
 	wg.Add(len(checkers))
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	for _, checker := range checkers {
 		go check(ctx, checker, username, &wg, results, errc)
@@ -60,7 +66,8 @@ func main() {
 		close(results)
 	}()
 
-	for {
+	// each checker sends exactly one message, either a result or an error
+	for i := 0; i < len(checkers); i++ {
 		select {
 		case err := <-errc:
 			//OLD
@@ -77,12 +84,8 @@ func main() {
 			if errors.As(err, &uae) {
 				fmt.Println(uae.Platform, uae.Username)
 			}
-			fmt.Println(err)
-			return
-		case res, ok := <-results:
-			if !ok {
-				return
-			}
+			fmt.Fprintln(os.Stderr, err)
+		case res := <-results:
 			fmt.Println(res)
 		}
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,7 +15,12 @@ import (
 	"sync/atomic"
 
 	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/bluesky"
 	"github.com/davidaparicio/namecheck/github"
+	"github.com/davidaparicio/namecheck/gitlab"
+	"github.com/davidaparicio/namecheck/hackernews"
+	"github.com/davidaparicio/namecheck/mastodon"
+	"github.com/davidaparicio/namecheck/reddit"
 	"github.com/davidaparicio/namecheck/tinder"
 	"github.com/gorilla/mux"
 )
@@ -108,28 +113,25 @@ func handleCheck(w http.ResponseWriter, r *http.Request) {
 	mu.Lock()
 	m[username]++
 	mu.Unlock()
-	var checkers []namecheck.Checker
-	//for i := 0; i < 50; i++ {
-	for i := 0; i < 3; i++ {
-		//Clients and Transports are safe for concurrent use by multiple
-		//goroutines and for efficiency should only be created once and re-used.
-		//So no DATA RACE ;)
-		/*t := &twitter.Twitter{
-			Client: http.DefaultClient,
-		}
-		i := &instagram.Instagram{
-			Client: http.DefaultClient,
-		}*/
-		git := &github.GitHub{
-			Client: http.DefaultClient,
-		}
-		tin := &tinder.Tinder{
-			Client: http.DefaultClient,
-		}
-		/*f := &falser.Falser{}
-		t := &truer.Truer{}
-		checkers = append(checkers, g, i, f, t)*/
-		checkers = append(checkers, git, tin)
+	//Clients and Transports are safe for concurrent use by multiple
+	//goroutines and for efficiency should only be created once and re-used.
+	//So no DATA RACE ;)
+	/*t := &twitter.Twitter{
+		Client: http.DefaultClient,
+	}
+	i := &instagram.Instagram{
+		Client: http.DefaultClient,
+	}
+	f := &falser.Falser{}
+	t := &truer.Truer{}*/
+	checkers := []namecheck.Checker{
+		&github.GitHub{Client: http.DefaultClient},
+		&gitlab.GitLab{Client: http.DefaultClient},
+		&reddit.Reddit{Client: http.DefaultClient},
+		&bluesky.Bluesky{Client: http.DefaultClient},
+		&mastodon.Mastodon{Client: http.DefaultClient},
+		&hackernews.HackerNews{Client: http.DefaultClient},
+		&tinder.Tinder{Client: http.DefaultClient},
 	}
 	results := make(chan Result)
 	/*ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -179,11 +181,12 @@ func check(
 	checker namecheck.Checker,
 	username string,
 	wg *sync.WaitGroup,
-	sem <-chan struct{},
+	sem chan struct{},
 	results chan<- Result,
 ) {
-	defer func() { <-sem }()
 	defer wg.Done()
+	sem <- struct{}{}
+	defer func() { <-sem }()
 	res := Result{
 		Username: username,
 		Platform: checker.String(),

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -1,0 +1,116 @@
+// Package gitlab provides primitives to check if an username
+// is available on GitLab.
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/internal"
+)
+
+type GitLab struct {
+	Client namecheck.Client
+}
+
+const (
+	minLen         = 2
+	maxLen         = 255
+	illegalPrefix  = "-"
+	illegalPattern = "--"
+)
+
+var legalPattern = regexp.MustCompile("^[0-9A-Za-z][-0-9A-Za-z_.]*$")
+var illegalSuffixes = []string{"-", ".", ".git", ".atom"}
+
+func (*GitLab) String() string {
+	return "GitLab"
+}
+
+func (*GitLab) IsValid(username string) bool {
+	return internal.IsLongEnough(username, minLen) &&
+		internal.IsShortEnough(username, maxLen) &&
+		containsNoIllegalPattern(username) &&
+		containsOnlyLegalChars(username) &&
+		containsNoIllegalPrefix(username) &&
+		containsNoIllegalSuffix(username)
+}
+
+// IsAvailable checks on GitLab, the availability of the requested username,
+// using the public REST API (no authentication required).
+// An empty result set indicates the username's availability.
+func (gl *GitLab) IsAvailable(ctx context.Context, username string) (bool, error) {
+	endpoint := fmt.Sprintf("https://gitlab.com/api/v4/users?username=%s", url.QueryEscape(username))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: gl.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+	resp, err := gl.Client.Do(req)
+	if err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: gl.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: gl.String(),
+			Cause:    fmt.Errorf("unexpected status code %d", resp.StatusCode),
+		}
+		return false, &err
+	}
+
+	var users []json.RawMessage
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&users); err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: gl.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+	return len(users) == 0, nil
+}
+
+func containsNoIllegalPattern(username string) bool {
+	return !strings.Contains(username, illegalPattern)
+}
+
+func containsOnlyLegalChars(username string) bool {
+	return legalPattern.MatchString(username)
+}
+
+func containsNoIllegalPrefix(username string) bool {
+	return !strings.HasPrefix(username, illegalPrefix)
+}
+
+func containsNoIllegalSuffix(username string) bool {
+	for _, suffix := range illegalSuffixes {
+		if strings.HasSuffix(username, suffix) {
+			return false
+		}
+	}
+	return true
+}

--- a/gitlab/gitlab_test.go
+++ b/gitlab/gitlab_test.go
@@ -1,0 +1,81 @@
+package gitlab_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/gitlab"
+	"github.com/davidaparicio/namecheck/stub"
+)
+
+var _ namecheck.Checker = (*gitlab.GitLab)(nil)
+
+func TestIsValid(t *testing.T) {
+	cases := []struct {
+		username string
+		want     bool
+	}{
+		{"davidaparicio", true},
+		{"david.aparicio", true},
+		{"david_aparicio", true},
+		{"a", false},               // too short
+		{"-david", false},          // illegal prefix
+		{"david-", false},          // illegal suffix
+		{"david.", false},          // illegal suffix
+		{"david.git", false},       // illegal suffix
+		{"david.atom", false},      // illegal suffix
+		{"david--aparicio", false}, // illegal pattern
+		{"david aparicio", false},  // illegal char
+	}
+	var gl gitlab.GitLab
+	for _, c := range cases {
+		if got := gl.IsValid(c.username); got != c.want {
+			t.Errorf("IsValid(%q) = %t; want %t", c.username, got, c.want)
+		}
+	}
+}
+
+func TestIsAvailableEmptyResult(t *testing.T) {
+	gl := gitlab.GitLab{
+		Client: stub.ClientWithStatusCodeAndBody(http.StatusOK, "[]"),
+	}
+	avail, err := gl.IsAvailable(context.Background(), "whatever")
+	if !avail || err != nil {
+		t.Error("IsAvailable must return true for an empty result set")
+	}
+}
+
+func TestIsAvailableNonEmptyResult(t *testing.T) {
+	gl := gitlab.GitLab{
+		Client: stub.ClientWithStatusCodeAndBody(http.StatusOK, `[{"id":42,"username":"whatever"}]`),
+	}
+	avail, err := gl.IsAvailable(context.Background(), "whatever")
+	if avail || err != nil {
+		t.Error("IsAvailable must return false for a non-empty result set")
+	}
+}
+
+func TestIsAvailableUnexpectedStatusCode(t *testing.T) {
+	gl := gitlab.GitLab{
+		Client: stub.ClientWithStatusCode(http.StatusTooManyRequests),
+	}
+	_, err := gl.IsAvailable(context.Background(), "whatever")
+	var uae *namecheck.UnknownAvailabilityError
+	if !errors.As(err, &uae) {
+		t.Error("IsAvailable must return an UnknownAvailabilityError on an unexpected status code")
+	}
+}
+
+func TestIsAvailableClientError(t *testing.T) {
+	gl := gitlab.GitLab{
+		Client: stub.ClientWithError(errors.New("oh no")),
+	}
+	_, err := gl.IsAvailable(context.Background(), "whatever")
+	var uae *namecheck.UnknownAvailabilityError
+	if !errors.As(err, &uae) {
+		t.Error("IsAvailable must return an UnknownAvailabilityError on a client error")
+	}
+}

--- a/hackernews/hackernews.go
+++ b/hackernews/hackernews.go
@@ -1,0 +1,93 @@
+// Package hackernews provides primitives to check if an username
+// is available on Hacker News.
+package hackernews
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/internal"
+)
+
+type HackerNews struct {
+	Client namecheck.Client
+}
+
+const (
+	minLen = 2
+	maxLen = 15
+)
+
+var legalPattern = regexp.MustCompile("^[-0-9A-Z_a-z]*$")
+
+func (*HackerNews) String() string {
+	return "HackerNews"
+}
+
+func (*HackerNews) IsValid(username string) bool {
+	return internal.IsLongEnough(username, minLen) &&
+		internal.IsShortEnough(username, maxLen) &&
+		containsOnlyLegalChars(username)
+}
+
+// IsAvailable checks on Hacker News, the availability of the requested
+// username, using the official Firebase-hosted API (no authentication
+// required). The endpoint always answers 200; a literal "null" body
+// indicates the username's availability.
+func (hn *HackerNews) IsAvailable(ctx context.Context, username string) (bool, error) {
+	endpoint := fmt.Sprintf("https://hacker-news.firebaseio.com/v0/user/%s.json", url.PathEscape(username))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: hn.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+	resp, err := hn.Client.Do(req)
+	if err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: hn.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: hn.String(),
+			Cause:    fmt.Errorf("unexpected status code %d", resp.StatusCode),
+		}
+		return false, &err
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: hn.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+	return strings.TrimSpace(string(bodyBytes)) == "null", nil
+}
+
+func containsOnlyLegalChars(username string) bool {
+	return legalPattern.MatchString(username)
+}

--- a/hackernews/hackernews_test.go
+++ b/hackernews/hackernews_test.go
@@ -1,0 +1,75 @@
+package hackernews_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/hackernews"
+	"github.com/davidaparicio/namecheck/stub"
+)
+
+var _ namecheck.Checker = (*hackernews.HackerNews)(nil)
+
+func TestIsValid(t *testing.T) {
+	cases := []struct {
+		username string
+		want     bool
+	}{
+		{"pg", true},
+		{"david_aparicio", true},
+		{"a", false},                    // too short
+		{"longer-than-15-chars", false}, // too long
+		{"david aparicio", false},       // illegal char
+	}
+	var hn hackernews.HackerNews
+	for _, c := range cases {
+		if got := hn.IsValid(c.username); got != c.want {
+			t.Errorf("IsValid(%q) = %t; want %t", c.username, got, c.want)
+		}
+	}
+}
+
+func TestIsAvailableNullBody(t *testing.T) {
+	hn := hackernews.HackerNews{
+		Client: stub.ClientWithStatusCodeAndBody(http.StatusOK, "null"),
+	}
+	avail, err := hn.IsAvailable(context.Background(), "whatever")
+	if !avail || err != nil {
+		t.Error("IsAvailable must return true on a null body")
+	}
+}
+
+func TestIsAvailableTaken(t *testing.T) {
+	hn := hackernews.HackerNews{
+		Client: stub.ClientWithStatusCodeAndBody(http.StatusOK, `{"id":"whatever","karma":1}`),
+	}
+	avail, err := hn.IsAvailable(context.Background(), "whatever")
+	if avail || err != nil {
+		t.Error("IsAvailable must return false on a non-null body")
+	}
+}
+
+func TestIsAvailableUnexpectedStatusCode(t *testing.T) {
+	hn := hackernews.HackerNews{
+		Client: stub.ClientWithStatusCode(http.StatusInternalServerError),
+	}
+	_, err := hn.IsAvailable(context.Background(), "whatever")
+	var uae *namecheck.UnknownAvailabilityError
+	if !errors.As(err, &uae) {
+		t.Error("IsAvailable must return an UnknownAvailabilityError on an unexpected status code")
+	}
+}
+
+func TestIsAvailableClientError(t *testing.T) {
+	hn := hackernews.HackerNews{
+		Client: stub.ClientWithError(errors.New("oh no")),
+	}
+	_, err := hn.IsAvailable(context.Background(), "whatever")
+	var uae *namecheck.UnknownAvailabilityError
+	if !errors.As(err, &uae) {
+		t.Error("IsAvailable must return an UnknownAvailabilityError on a client error")
+	}
+}

--- a/mastodon/mastodon.go
+++ b/mastodon/mastodon.go
@@ -1,0 +1,86 @@
+// Package mastodon provides primitives to check if an username
+// is available on Mastodon (on the mastodon.social instance).
+package mastodon
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/internal"
+)
+
+type Mastodon struct {
+	Client namecheck.Client
+}
+
+const (
+	minLen = 1
+	maxLen = 30
+)
+
+var legalPattern = regexp.MustCompile("^[0-9A-Z_a-z]*$")
+
+func (*Mastodon) String() string {
+	return "Mastodon"
+}
+
+func (*Mastodon) IsValid(username string) bool {
+	return internal.IsLongEnough(username, minLen) &&
+		internal.IsShortEnough(username, maxLen) &&
+		containsOnlyLegalChars(username)
+}
+
+// IsAvailable checks on Mastodon (mastodon.social instance),
+// the availability of the requested username, using the public REST API
+// (no authentication required).
+// A 404 status code on the account lookup indicates the username's
+// availability.
+func (mast *Mastodon) IsAvailable(ctx context.Context, username string) (bool, error) {
+	endpoint := fmt.Sprintf("https://mastodon.social/api/v1/accounts/lookup?acct=%s", url.QueryEscape(username))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: mast.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+	resp, err := mast.Client.Do(req)
+	if err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: mast.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return true, nil
+	case http.StatusOK:
+		return false, nil
+	default:
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: mast.String(),
+			Cause:    fmt.Errorf("unexpected status code %d", resp.StatusCode),
+		}
+		return false, &err
+	}
+}
+
+func containsOnlyLegalChars(username string) bool {
+	return legalPattern.MatchString(username)
+}

--- a/mastodon/mastodon_test.go
+++ b/mastodon/mastodon_test.go
@@ -1,0 +1,75 @@
+package mastodon_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/mastodon"
+	"github.com/davidaparicio/namecheck/stub"
+)
+
+var _ namecheck.Checker = (*mastodon.Mastodon)(nil)
+
+func TestIsValid(t *testing.T) {
+	cases := []struct {
+		username string
+		want     bool
+	}{
+		{"Gargron", true},
+		{"david_aparicio", true},
+		{"", false}, // too short
+		{"obviously-longer-than-thirty-characters", false}, // too long
+		{"david-aparicio", false},                          // illegal char
+	}
+	var mast mastodon.Mastodon
+	for _, c := range cases {
+		if got := mast.IsValid(c.username); got != c.want {
+			t.Errorf("IsValid(%q) = %t; want %t", c.username, got, c.want)
+		}
+	}
+}
+
+func TestIsAvailableNotFound(t *testing.T) {
+	mast := mastodon.Mastodon{
+		Client: stub.ClientWithStatusCodeAndBody(http.StatusNotFound, `{"error":"Record not found"}`),
+	}
+	avail, err := mast.IsAvailable(context.Background(), "whatever")
+	if !avail || err != nil {
+		t.Error("IsAvailable must return true on a 404 status code")
+	}
+}
+
+func TestIsAvailableTaken(t *testing.T) {
+	mast := mastodon.Mastodon{
+		Client: stub.ClientWithStatusCode(http.StatusOK),
+	}
+	avail, err := mast.IsAvailable(context.Background(), "whatever")
+	if avail || err != nil {
+		t.Error("IsAvailable must return false on a 200 status code")
+	}
+}
+
+func TestIsAvailableUnexpectedStatusCode(t *testing.T) {
+	mast := mastodon.Mastodon{
+		Client: stub.ClientWithStatusCode(http.StatusTooManyRequests),
+	}
+	_, err := mast.IsAvailable(context.Background(), "whatever")
+	var uae *namecheck.UnknownAvailabilityError
+	if !errors.As(err, &uae) {
+		t.Error("IsAvailable must return an UnknownAvailabilityError on an unexpected status code")
+	}
+}
+
+func TestIsAvailableClientError(t *testing.T) {
+	mast := mastodon.Mastodon{
+		Client: stub.ClientWithError(errors.New("oh no")),
+	}
+	_, err := mast.IsAvailable(context.Background(), "whatever")
+	var uae *namecheck.UnknownAvailabilityError
+	if !errors.As(err, &uae) {
+		t.Error("IsAvailable must return an UnknownAvailabilityError on a client error")
+	}
+}

--- a/reddit/reddit.go
+++ b/reddit/reddit.go
@@ -1,0 +1,86 @@
+// Package reddit provides primitives to check if an username
+// is available on Reddit.
+package reddit
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/internal"
+)
+
+type Reddit struct {
+	Client namecheck.Client
+}
+
+const (
+	minLen = 3
+	maxLen = 20
+)
+
+var legalPattern = regexp.MustCompile("^[-0-9A-Z_a-z]*$")
+
+func (*Reddit) String() string {
+	return "Reddit"
+}
+
+func (*Reddit) IsValid(username string) bool {
+	return internal.IsLongEnough(username, minLen) &&
+		internal.IsShortEnough(username, maxLen) &&
+		containsOnlyLegalChars(username)
+}
+
+// IsAvailable checks on Reddit, the availability of the requested username.
+// A 404 status code on the user's about page indicates the username's
+// availability.
+func (red *Reddit) IsAvailable(ctx context.Context, username string) (bool, error) {
+	endpoint := fmt.Sprintf("https://www.reddit.com/user/%s/about.json", url.PathEscape(username))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: red.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+	// Reddit rejects requests without a User-Agent header.
+	req.Header.Set("User-Agent", "namecheck/1.0 (https://github.com/davidaparicio/namecheck)")
+	resp, err := red.Client.Do(req)
+	if err != nil {
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: red.String(),
+			Cause:    err,
+		}
+		return false, &err
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return true, nil
+	case http.StatusOK:
+		return false, nil
+	default:
+		err := namecheck.UnknownAvailabilityError{
+			Username: username,
+			Platform: red.String(),
+			Cause:    fmt.Errorf("unexpected status code %d", resp.StatusCode),
+		}
+		return false, &err
+	}
+}
+
+func containsOnlyLegalChars(username string) bool {
+	return legalPattern.MatchString(username)
+}

--- a/reddit/reddit_test.go
+++ b/reddit/reddit_test.go
@@ -1,0 +1,76 @@
+package reddit_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/davidaparicio/namecheck"
+	"github.com/davidaparicio/namecheck/reddit"
+	"github.com/davidaparicio/namecheck/stub"
+)
+
+var _ namecheck.Checker = (*reddit.Reddit)(nil)
+
+func TestIsValid(t *testing.T) {
+	cases := []struct {
+		username string
+		want     bool
+	}{
+		{"spez", true},
+		{"david-aparicio", true},
+		{"david_aparicio", true},
+		{"ab", false},                            // too short
+		{"longer-than-twenty-characters", false}, // too long
+		{"david aparicio", false},                // illegal char
+	}
+	var red reddit.Reddit
+	for _, c := range cases {
+		if got := red.IsValid(c.username); got != c.want {
+			t.Errorf("IsValid(%q) = %t; want %t", c.username, got, c.want)
+		}
+	}
+}
+
+func TestIsAvailableNotFound(t *testing.T) {
+	red := reddit.Reddit{
+		Client: stub.ClientWithStatusCode(http.StatusNotFound),
+	}
+	avail, err := red.IsAvailable(context.Background(), "whatever")
+	if !avail || err != nil {
+		t.Error("IsAvailable must return true on a 404 status code")
+	}
+}
+
+func TestIsAvailableTaken(t *testing.T) {
+	red := reddit.Reddit{
+		Client: stub.ClientWithStatusCode(http.StatusOK),
+	}
+	avail, err := red.IsAvailable(context.Background(), "whatever")
+	if avail || err != nil {
+		t.Error("IsAvailable must return false on a 200 status code")
+	}
+}
+
+func TestIsAvailableUnexpectedStatusCode(t *testing.T) {
+	red := reddit.Reddit{
+		Client: stub.ClientWithStatusCode(http.StatusTooManyRequests),
+	}
+	_, err := red.IsAvailable(context.Background(), "whatever")
+	var uae *namecheck.UnknownAvailabilityError
+	if !errors.As(err, &uae) {
+		t.Error("IsAvailable must return an UnknownAvailabilityError on an unexpected status code")
+	}
+}
+
+func TestIsAvailableClientError(t *testing.T) {
+	red := reddit.Reddit{
+		Client: stub.ClientWithError(errors.New("oh no")),
+	}
+	_, err := red.IsAvailable(context.Background(), "whatever")
+	var uae *namecheck.UnknownAvailabilityError
+	if !errors.As(err, &uae) {
+		t.Error("IsAvailable must return an UnknownAvailabilityError on a client error")
+	}
+}


### PR DESCRIPTION
## Summary
This PR extends the namecheck tool to support checking username availability on five additional platforms: GitLab, Reddit, Bluesky, Mastodon, and Hacker News. Each platform has its own package with validation rules and availability checking logic.

## Key Changes

- **New platform packages**: Added five new packages (`gitlab`, `reddit`, `bluesky`, `mastodon`, `hackernews`) with implementations of the `namecheck.Checker` interface
  - Each package includes platform-specific username validation rules (length, character restrictions, prefix/suffix rules)
  - Each package implements availability checking via public APIs without requiring authentication

- **Platform-specific implementations**:
  - **GitLab**: Uses public REST API (`/api/v4/users?username=`) - empty result set indicates availability
  - **Reddit**: Checks user's about page (`/user/<username>/about.json`) - 404 indicates availability
  - **Bluesky**: Uses AT Protocol API to resolve handles under `.bsky.social` domain - 400 status indicates availability
  - **Mastodon**: Uses public REST API (`/api/v1/accounts/lookup`) - 404 indicates availability
  - **Hacker News**: Uses Firebase API - `null` response body indicates availability

- **Comprehensive test coverage**: Added test files for each new platform covering validation rules, availability checks, error handling, and edge cases

- **CLI and server updates**: 
  - Updated both `cmd/cli/main.go` and `cmd/server/main.go` to include all new checkers
  - Increased timeout in CLI from 1 second to 5 seconds to accommodate more concurrent requests
  - Fixed semaphore usage in server's `check` function to properly acquire before deferring release

- **Documentation**: Updated README.md with a table of supported websites and their checking mechanisms

## Notable Implementation Details

- All platform packages follow a consistent pattern: `String()` method for platform name, `IsValid()` for client-side validation, and `IsAvailable()` for API-based availability checking
- Error handling uses the `UnknownAvailabilityError` type for network/API errors
- Each platform has distinct username rules (e.g., GitLab allows dots and underscores, Bluesky only allows hyphens)
- Proper resource cleanup with deferred response body closing
- User-Agent header required for Reddit API requests

https://claude.ai/code/session_01Bcp9mRMtS4w886JdfMQCcS